### PR TITLE
Bug fix for tie-game being identified if a player wins when the board is full

### DIFF
--- a/src/main/java/cs/ualberta/cmput402/tictactoe/board/Board.java
+++ b/src/main/java/cs/ualberta/cmput402/tictactoe/board/Board.java
@@ -54,12 +54,15 @@ public class Board {
 
             if (hasWon(row, col))
                 winner = currentPlayer;
+            else if (checkTie()) {
+                tieFlag = checkTie();
+            }
             else if(currentPlayer == Player.X)
                 currentPlayer = Player.O;
             else
                 currentPlayer = Player.X;
 
-            tieFlag = checkTie();
+
         }
 
     }

--- a/src/test/java/BoardTest.java
+++ b/src/test/java/BoardTest.java
@@ -187,9 +187,25 @@ public class BoardTest {
         board.playMove(2,1);
         board.playMove(1,0); //player 0
         board.playMove(1,2);
+        board.playMove(2,2); //player 0
+        board.playMove(2,0);
+
+        assert(board.isTie() == true);
+    }
+
+    @Test
+    public void testNoTieGameWhenPlayerWinsOnFullBoard() throws InvalidMoveException {
+
+        board.playMove(0,0);
+        board.playMove(0,1); //player 0
+        board.playMove(0,2);
+        board.playMove(1,1); //player 0
+        board.playMove(2,1);
+        board.playMove(1,0); //player 0
+        board.playMove(1,2);
         board.playMove(2,0); //player 0
         board.playMove(2,2);
 
-        assert(board.isTie() == true);
+        assert(board.isTie() == false);
     }
 }


### PR DESCRIPTION
resolves #11 

In this pull request:
- I wrote tests to reproduce the bug of ties being identified when a player wins on a full board.
- I changed a few lines in the game logic to fix the bug
